### PR TITLE
refactored namedmatrix inits

### DIFF
--- a/src/MatrixOps.chpl
+++ b/src/MatrixOps.chpl
@@ -17,13 +17,31 @@ class NamedMatrix {
       cols: BiMap = new BiMap();
 
    proc init() {
-     super.init();
+     super.init();  //NAMEDMATRIX DOESNT EXPLICITLY INHERIT ANYTHING SO IS THIS NECESSARY??
    }
 
    proc init(X) {
      this.D = {X.domain.dim(1), X.domain.dim(2)};
      super.init();
      this.loadX(X);
+   }
+
+   proc init(X, names: [] string) {
+     this.init(X);
+     try! this.setRowNames(names);
+     try! this.setColNames(names);
+   }
+
+   proc init(X, rownames: [] string, colnames: [] string) {
+     this.init(X);
+     try! this.setRowNames(rownames);
+     try! this.setColNames(colnames);
+   }
+
+   proc init(N: NamedMatrix) {
+     this.init(N.X);
+     this.rows = N.rows;
+     this.cols = N.cols;
    }
 }
 

--- a/src/MatrixOps.chpl
+++ b/src/MatrixOps.chpl
@@ -17,12 +17,12 @@ class NamedMatrix {
       cols: BiMap = new BiMap();
 
    proc init() {
-     super.init();  //NAMEDMATRIX DOESNT EXPLICITLY INHERIT ANYTHING SO IS THIS NECESSARY??
+     this.initDone(); // NAMEDMATRIX DOESNT EXPLICITLY INHERIT ANYTHING SO IS THIS NECESSARY??
    }
 
    proc init(X) {
      this.D = {X.domain.dim(1), X.domain.dim(2)};
-     super.init();
+     this.initDone();
      this.loadX(X);
    }
 

--- a/src/NumSuch.chpl
+++ b/src/NumSuch.chpl
@@ -71,7 +71,7 @@ examples::
     Create an empty BiMap.
     */
     proc init() {
-      super.init();
+      this.initDone();
     }
 
     /*


### PR DESCRIPTION
Brad's explanation of what went wrong in last weeks Chingon issue illuminated a few things. I've restructured the `NamedMatrix` portion of`NumSuch` in a couple ways:

inits are defined in a tree structure so that more informative `init`s reference prior less informative ones which helps to clean up the code and enforce self-consistency.

an init that builds a `NamedMatrix` out of a `NamedMatrix` was added because its absence was preventing us from building `Graph`s directly from `NamedMatrix` objects.